### PR TITLE
Handle Fetch error response

### DIFF
--- a/crawlera_fetch/middleware.py
+++ b/crawlera_fetch/middleware.py
@@ -210,7 +210,9 @@ class CrawleraFetchMiddleware:
             "body": json_response,
         }
         respcls = responsetypes.from_args(
-            headers=json_response["headers"], url=json_response["url"], body=json_response["body"],
+            headers=json_response["headers"],
+            url=json_response["url"],
+            body=json_response["body"],
         )
         return response.replace(
             cls=respcls,

--- a/crawlera_fetch/middleware.py
+++ b/crawlera_fetch/middleware.py
@@ -180,6 +180,24 @@ class CrawleraFetchMiddleware:
                 logger.error(log_msg)
                 return response
 
+        if json_response.get('crawlera_error'):
+            error = json_response["crawlera_error"]
+            message = json_response["body"]
+            self.stats.inc_value("crawlera_fetch/response_error")
+            self.stats.inc_value("crawlera_fetch/response_error/{}".format(error))
+            log_msg = "Error downloading <{} {}> (Original status: {}, Fetch API error message: {})"
+            log_msg = log_msg.format(
+                crawlera_meta["original_request"]["method"],
+                crawlera_meta["original_request"]["url"],
+                json_response["original_status"],
+                message,
+            )
+            if self.raise_on_error:
+                raise CrawleraFetchException(log_msg)
+            else:
+                logger.error(log_msg)
+                return response
+
         self.stats.inc_value(
             "crawlera_fetch/response_status_count/{}".format(json_response["original_status"])
         )

--- a/crawlera_fetch/middleware.py
+++ b/crawlera_fetch/middleware.py
@@ -180,12 +180,14 @@ class CrawleraFetchMiddleware:
                 logger.error(log_msg)
                 return response
 
-        if json_response.get('crawlera_error'):
+        if json_response.get("crawlera_error"):
             error = json_response["crawlera_error"]
             message = json_response["body"]
             self.stats.inc_value("crawlera_fetch/response_error")
             self.stats.inc_value("crawlera_fetch/response_error/{}".format(error))
-            log_msg = "Error downloading <{} {}> (Original status: {}, Fetch API error message: {})"
+            log_msg = (
+                "Error downloading <{} {}> (Original status: {}, Fetch API error message: {})"
+            )
             log_msg = log_msg.format(
                 crawlera_meta["original_request"]["method"],
                 crawlera_meta["original_request"]["url"],

--- a/tests/data/requests.py
+++ b/tests/data/requests.py
@@ -111,7 +111,9 @@ test_requests.append(
 test_requests.append(
     {
         "original": Request(
-            url="https://example.org", method="HEAD", meta={"crawlera_fetch": {"skip": True}},
+            url="https://example.org",
+            method="HEAD",
+            meta={"crawlera_fetch": {"skip": True}},
         ),
         "expected": None,
     }

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -98,12 +98,18 @@ def test_process_response_error():
                     }
                 },
             ),
-            body=b'{"url":"https://example.org",'
-                 b'"original_status":503,"headers":{},'
-                 b'"crawlera_status":"fail",'
-                 b'"crawlera_error":"serverbusy",'
-                 b'"body_encoding":"plain",'
-                 b'"body":"Server busy: too many outstanding requests"}'
+            body=json.dumps(
+                {
+                    "url": "https://example.org",
+                    "original_status": 503,
+                    "headers": {},
+                    "crawlera_status": "fail",
+                    "crawlera_error": "serverbusy",
+                    "body_encoding": "plain",
+                    "body": "Server busy: too many outstanding requests",
+                }
+            ),
+            encoding="utf8",
         ),
     ]
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -87,6 +87,24 @@ def test_process_response_error():
             ),
             body=b'{"Bad": "JSON',
         ),
+        TextResponse(
+            url="https://crawlera.com/fake/api/endpoint",
+            request=Request(
+                url="https://crawlera.com/fake/api/endpoint",
+                meta={
+                    "crawlera_fetch": {
+                        "timing": {"start_ts": mocked_time()},
+                        "original_request": {"url": "https://example.org", "method": "GET"},
+                    }
+                },
+            ),
+            body=b'{"url":"https://example.org",'
+                 b'"original_status":503,"headers":{},'
+                 b'"crawlera_status":"fail",'
+                 b'"crawlera_error":"serverbusy",'
+                 b'"body_encoding":"plain",'
+                 b'"body":"Server busy: too many outstanding requests"}'
+        ),
     ]
 
     middleware_raise = get_test_middleware(settings={"CRAWLERA_FETCH_RAISE_ON_ERROR": True})
@@ -94,9 +112,10 @@ def test_process_response_error():
         with pytest.raises(CrawleraFetchException):
             middleware_raise.process_response(response.request, response, Spider("foo"))
 
-    assert middleware_raise.stats.get_value("crawlera_fetch/response_error") == 2
+    assert middleware_raise.stats.get_value("crawlera_fetch/response_error") == 3
     assert middleware_raise.stats.get_value("crawlera_fetch/response_error/bad_proxy_auth") == 1
     assert middleware_raise.stats.get_value("crawlera_fetch/response_error/JSONDecodeError") == 1
+    assert middleware_raise.stats.get_value("crawlera_fetch/response_error/serverbusy") == 1
 
     middleware_log = get_test_middleware(settings={"CRAWLERA_FETCH_RAISE_ON_ERROR": False})
     with LogCapture() as logs:
@@ -115,8 +134,14 @@ def test_process_response_error():
             "ERROR",
             "Error decoding <GET https://example.org> (status: 200, message: Unterminated string starting at, lineno: 1, colno: 9)",  # noqa: E501
         ),
+        (
+            "crawlera-fetch-middleware",
+            "ERROR",
+            "Error downloading <GET https://example.org> (Original status: 503, Fetch API error message: Server busy: too many outstanding requests)",  # noqa: E501
+        ),
     )
 
-    assert middleware_log.stats.get_value("crawlera_fetch/response_error") == 2
+    assert middleware_log.stats.get_value("crawlera_fetch/response_error") == 3
     assert middleware_log.stats.get_value("crawlera_fetch/response_error/bad_proxy_auth") == 1
     assert middleware_log.stats.get_value("crawlera_fetch/response_error/JSONDecodeError") == 1
+    assert middleware_log.stats.get_value("crawlera_fetch/response_error/serverbusy") == 1


### PR DESCRIPTION
@elacuesta
 
Improved logging for these types of responses:
```
$ curl -s -u $FETCH_APIKEY: http://fetch.crawlera.com:8010/fetch/v2/ -d '{"url":"https://httpbin.org/status/200", "script":"", "parameters":{"use_residential":true}, "region":"fr"}' -H "Content-Type:application/json" | jq
{
  "url": "https://httpbin.org/status/200",
  "original_status": 503,
  "headers": {},
  "crawlera_status": "fail",
  "crawlera_error": "serverbusy",
  "body_encoding": "plain",
  "body": "Server busy: too many outstanding requests"
}
```