### PR TITLE
Test request serialization for non-default callbacks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up py3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
 
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up py${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,27 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e py${{ matrix.python-version }}
+      run: tox -e py
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash)
+
+  tests-py35-pinned:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up py35
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+
+    - name: Install tox
+      run: pip install tox
+
+    - name: Run tests
+      run: tox -e py35-pinned
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash)

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,16 +1,3 @@
-from scrapy import Spider
-
-
-class DummySpider(Spider):
-    name = "dummy"
-
-    def parse(self, response):
-        pass
-
-
-dummy_spider = DummySpider()
-
-
 SETTINGS = {
     "CRAWLERA_FETCH_ENABLED": True,
     "CRAWLERA_FETCH_URL": "https://example.org",

--- a/tests/data/requests.py
+++ b/tests/data/requests.py
@@ -4,8 +4,8 @@ from scrapy import Request, FormRequest
 from scrapy.utils.reqser import request_to_dict
 from w3lib.http import basic_auth_header
 
-from tests.data import dummy_spider, SETTINGS
-from tests.utils import mocked_time
+from tests.data import SETTINGS
+from tests.utils import foo_spider, mocked_time
 
 
 test_requests = []
@@ -26,6 +26,7 @@ original1 = Request(
 )
 expected1 = Request(
     url=SETTINGS["CRAWLERA_FETCH_URL"],
+    callback=foo_spider.foo_callback,
     method="POST",
     headers={
         "Authorization": basic_auth_header(SETTINGS["CRAWLERA_FETCH_APIKEY"], ""),
@@ -41,7 +42,7 @@ expected1 = Request(
                 "iptype": "datacenter",
                 "device": "mobile",
             },
-            "original_request": request_to_dict(original1, spider=dummy_spider),
+            "original_request": request_to_dict(original1, spider=foo_spider),
             "timing": {"start_ts": mocked_time()},
         },
         "download_slot": "httpbin.org",
@@ -68,6 +69,7 @@ test_requests.append(
 
 original2 = FormRequest(
     url="https://httpbin.org/post",
+    callback=foo_spider.foo_callback,
     meta={"crawlera_fetch": {"args": {"device": "desktop"}}},
     formdata={"foo": "bar"},
 )
@@ -83,7 +85,7 @@ expected2 = FormRequest(
     meta={
         "crawlera_fetch": {
             "args": {"device": "desktop"},
-            "original_request": request_to_dict(original2, spider=dummy_spider),
+            "original_request": request_to_dict(original2, spider=foo_spider),
             "timing": {"start_ts": mocked_time()},
         },
         "download_slot": "httpbin.org",

--- a/tests/data/requests.py
+++ b/tests/data/requests.py
@@ -8,111 +8,113 @@ from tests.data import SETTINGS
 from tests.utils import foo_spider, mocked_time
 
 
-test_requests = []
+def get_test_requests():
+    test_requests = []
 
-original1 = Request(
-    url="https://httpbin.org/anything",
-    method="GET",
-    meta={
-        "crawlera_fetch": {
-            "args": {
+    original1 = Request(
+        url="https://httpbin.org/anything",
+        method="GET",
+        meta={
+            "crawlera_fetch": {
+                "args": {
+                    "render": "no",
+                    "region": "us",
+                    "iptype": "datacenter",
+                    "device": "mobile",
+                }
+            }
+        },
+    )
+    expected1 = Request(
+        url=SETTINGS["CRAWLERA_FETCH_URL"],
+        callback=foo_spider.foo_callback,
+        method="POST",
+        headers={
+            "Authorization": basic_auth_header(SETTINGS["CRAWLERA_FETCH_APIKEY"], ""),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Crawlera-JobId": "1/2/3",
+        },
+        meta={
+            "crawlera_fetch": {
+                "args": {
+                    "render": "no",
+                    "region": "us",
+                    "iptype": "datacenter",
+                    "device": "mobile",
+                },
+                "original_request": request_to_dict(original1, spider=foo_spider),
+                "timing": {"start_ts": mocked_time()},
+            },
+            "download_slot": "httpbin.org",
+        },
+        body=json.dumps(
+            {
+                "url": "https://httpbin.org/anything",
+                "method": "GET",
+                "body": "",
                 "render": "no",
                 "region": "us",
                 "iptype": "datacenter",
                 "device": "mobile",
             }
-        }
-    },
-)
-expected1 = Request(
-    url=SETTINGS["CRAWLERA_FETCH_URL"],
-    callback=foo_spider.foo_callback,
-    method="POST",
-    headers={
-        "Authorization": basic_auth_header(SETTINGS["CRAWLERA_FETCH_APIKEY"], ""),
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "X-Crawlera-JobId": "1/2/3",
-    },
-    meta={
-        "crawlera_fetch": {
-            "args": {
-                "render": "no",
-                "region": "us",
-                "iptype": "datacenter",
-                "device": "mobile",
-            },
-            "original_request": request_to_dict(original1, spider=foo_spider),
-            "timing": {"start_ts": mocked_time()},
-        },
-        "download_slot": "httpbin.org",
-    },
-    body=json.dumps(
-        {
-            "url": "https://httpbin.org/anything",
-            "method": "GET",
-            "body": "",
-            "render": "no",
-            "region": "us",
-            "iptype": "datacenter",
-            "device": "mobile",
-        }
-    ),
-)
-test_requests.append(
-    {
-        "original": original1,
-        "expected": expected1,
-    }
-)
-
-
-original2 = FormRequest(
-    url="https://httpbin.org/post",
-    callback=foo_spider.foo_callback,
-    meta={"crawlera_fetch": {"args": {"device": "desktop"}}},
-    formdata={"foo": "bar"},
-)
-expected2 = FormRequest(
-    url=SETTINGS["CRAWLERA_FETCH_URL"],
-    method="POST",
-    headers={
-        "Authorization": basic_auth_header(SETTINGS["CRAWLERA_FETCH_APIKEY"], ""),
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "X-Crawlera-JobId": "1/2/3",
-    },
-    meta={
-        "crawlera_fetch": {
-            "args": {"device": "desktop"},
-            "original_request": request_to_dict(original2, spider=foo_spider),
-            "timing": {"start_ts": mocked_time()},
-        },
-        "download_slot": "httpbin.org",
-    },
-    body=json.dumps(
-        {
-            "url": "https://httpbin.org/post",
-            "method": "POST",
-            "body": "foo=bar",
-            "device": "desktop",
-        }
-    ),
-)
-test_requests.append(
-    {
-        "original": original2,
-        "expected": expected2,
-    }
-)
-
-test_requests.append(
-    {
-        "original": Request(
-            url="https://example.org",
-            method="HEAD",
-            meta={"crawlera_fetch": {"skip": True}},
         ),
-        "expected": None,
-    }
-)
+    )
+    test_requests.append(
+        {
+            "original": original1,
+            "expected": expected1,
+        }
+    )
+
+    original2 = FormRequest(
+        url="https://httpbin.org/post",
+        callback=foo_spider.foo_callback,
+        meta={"crawlera_fetch": {"args": {"device": "desktop"}}},
+        formdata={"foo": "bar"},
+    )
+    expected2 = FormRequest(
+        url=SETTINGS["CRAWLERA_FETCH_URL"],
+        method="POST",
+        headers={
+            "Authorization": basic_auth_header(SETTINGS["CRAWLERA_FETCH_APIKEY"], ""),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Crawlera-JobId": "1/2/3",
+        },
+        meta={
+            "crawlera_fetch": {
+                "args": {"device": "desktop"},
+                "original_request": request_to_dict(original2, spider=foo_spider),
+                "timing": {"start_ts": mocked_time()},
+            },
+            "download_slot": "httpbin.org",
+        },
+        body=json.dumps(
+            {
+                "url": "https://httpbin.org/post",
+                "method": "POST",
+                "body": "foo=bar",
+                "device": "desktop",
+            }
+        ),
+    )
+    test_requests.append(
+        {
+            "original": original2,
+            "expected": expected2,
+        }
+    )
+
+    test_requests.append(
+        {
+            "original": Request(
+                url="https://example.org",
+                method="HEAD",
+                meta={"crawlera_fetch": {"skip": True}},
+            ),
+            "expected": None,
+        }
+    )
+
+    return test_requests

--- a/tests/data/responses.py
+++ b/tests/data/responses.py
@@ -3,8 +3,8 @@ from scrapy.http.response.html import HtmlResponse
 from scrapy.http.response.text import TextResponse
 from scrapy.utils.reqser import request_to_dict
 
-from tests.data import dummy_spider, SETTINGS
-from tests.utils import mocked_time
+from tests.data import SETTINGS
+from tests.utils import foo_spider, mocked_time
 
 
 test_responses = []
@@ -29,7 +29,7 @@ test_responses.append(
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://fake.host.com"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },
@@ -65,7 +65,7 @@ test_responses.append(
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://httpbin.org/get"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },
@@ -111,7 +111,7 @@ test_responses.append(
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://example.org"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -63,14 +63,18 @@ def test_log_formatter_scrapy_2():
         assert logstr == "Crawled (200) %s (referer: None)" % str(original)
 
         # spider_error
-        result = logformatter.spider_error(Failure(Exception("exc")), processed, response, foo_spider)
+        result = logformatter.spider_error(
+            Failure(Exception("exc")), processed, response, foo_spider
+        )
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=1, exc_info=None, **result)
         logstr = formatter.format(record)
         assert logstr == "Spider error processing %s (referer: None)" % str(original)
 
         # download_error
-        result = logformatter.download_error(Failure(Exception("exc")), processed, foo_spider, "error")
+        result = logformatter.download_error(
+            Failure(Exception("exc")), processed, foo_spider, "error"
+        )
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=2, exc_info=None, **result)
         logstr = formatter.format(record)

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -2,14 +2,14 @@ import unittest
 from copy import deepcopy
 from logging import LogRecord, Formatter
 
-from scrapy import Spider, version_info as scrapy_version
+from scrapy import version_info as scrapy_version
 from scrapy.http.response import Response
 from twisted.python.failure import Failure
 
 from crawlera_fetch.logformatter import CrawleraFetchLogFormatter
 
 from tests.data.requests import test_requests
-from tests.utils import get_test_middleware
+from tests.utils import foo_spider, get_test_middleware
 
 
 @unittest.skipIf(scrapy_version > (2, 0, 0), "Scrapy < 2.0 only")
@@ -17,12 +17,11 @@ def test_log_formatter_scrapy_1():
     middleware = get_test_middleware()
     logformatter = CrawleraFetchLogFormatter()
     formatter = Formatter()
-    spider = Spider("foo")
 
     for case in deepcopy(test_requests):
         original = case["original"]
         response = Response(original.url)
-        processed = middleware.process_request(original, spider)
+        processed = middleware.process_request(original, foo_spider)
 
         crawlera_meta = original.meta.get("crawlera_fetch") or {}
         if crawlera_meta.get("skip"):
@@ -30,7 +29,7 @@ def test_log_formatter_scrapy_1():
             continue
 
         # crawled
-        result = logformatter.crawled(processed, response, spider)
+        result = logformatter.crawled(processed, response, foo_spider)
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=1, exc_info=None, **result)
         logstr = formatter.format(record)
@@ -45,12 +44,11 @@ def test_log_formatter_scrapy_2():
     middleware = get_test_middleware()
     logformatter = CrawleraFetchLogFormatter()
     formatter = Formatter()
-    spider = Spider("foo")
 
     for case in deepcopy(test_requests):
         original = case["original"]
         response = Response(original.url)
-        processed = middleware.process_request(original, spider)
+        processed = middleware.process_request(original, foo_spider)
 
         crawlera_meta = original.meta.get("crawlera_fetch") or {}
         if crawlera_meta.get("skip"):
@@ -58,22 +56,22 @@ def test_log_formatter_scrapy_2():
             continue
 
         # crawled
-        result = logformatter.crawled(processed, response, spider)
+        result = logformatter.crawled(processed, response, foo_spider)
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=1, exc_info=None, **result)
         logstr = formatter.format(record)
         assert logstr == "Crawled (200) %s (referer: None)" % str(original)
 
         # spider_error
-        result = logformatter.spider_error(Failure(Exception("exc")), processed, response, spider)
+        result = logformatter.spider_error(Failure(Exception("exc")), processed, response, foo_spider)
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=1, exc_info=None, **result)
         logstr = formatter.format(record)
         assert logstr == "Spider error processing %s (referer: None)" % str(original)
 
         # download_error
-        result = logformatter.download_error(Failure(Exception("exc")), processed, spider, "foo")
+        result = logformatter.download_error(Failure(Exception("exc")), processed, foo_spider, "error")
         assert result["args"]["request"] == str(original)
         record = LogRecord(name="logger", pathname="n/a", lineno=2, exc_info=None, **result)
         logstr = formatter.format(record)
-        assert logstr == "Error downloading %s: foo" % str(original)
+        assert logstr == "Error downloading %s: error" % str(original)

--- a/tests/test_logformatter.py
+++ b/tests/test_logformatter.py
@@ -1,5 +1,4 @@
 import unittest
-from copy import deepcopy
 from logging import LogRecord, Formatter
 
 from scrapy import version_info as scrapy_version
@@ -8,7 +7,7 @@ from twisted.python.failure import Failure
 
 from crawlera_fetch.logformatter import CrawleraFetchLogFormatter
 
-from tests.data.requests import test_requests
+from tests.data.requests import get_test_requests
 from tests.utils import foo_spider, get_test_middleware
 
 
@@ -18,7 +17,7 @@ def test_log_formatter_scrapy_1():
     logformatter = CrawleraFetchLogFormatter()
     formatter = Formatter()
 
-    for case in deepcopy(test_requests):
+    for case in get_test_requests():
         original = case["original"]
         response = Response(original.url)
         processed = middleware.process_request(original, foo_spider)
@@ -45,7 +44,7 @@ def test_log_formatter_scrapy_2():
     logformatter = CrawleraFetchLogFormatter()
     formatter = Formatter()
 
-    for case in deepcopy(test_requests):
+    for case in get_test_requests():
         original = case["original"]
         response = Response(original.url)
         processed = middleware.process_request(original, foo_spider)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -8,9 +8,8 @@ from scrapy import Request
 
 from crawlera_fetch import DownloadSlotPolicy
 
-from tests.data import dummy_spider
 from tests.data.requests import test_requests
-from tests.utils import get_test_middleware, mocked_time
+from tests.utils import foo_spider, get_test_middleware, mocked_time
 
 
 @contextmanager
@@ -34,7 +33,7 @@ def test_process_request():
         expected = case["expected"]
 
         with shub_jobkey_env_variable():
-            processed = middleware.process_request(original, dummy_spider)
+            processed = middleware.process_request(original, foo_spider)
 
         crawlera_meta = original.meta.get("crawlera_fetch")
         if crawlera_meta.get("skip"):
@@ -63,7 +62,7 @@ def test_process_request_single_download_slot():
             expected.meta["download_slot"] = "__crawlera_fetch__"
 
         with shub_jobkey_env_variable():
-            processed = middleware.process_request(original, dummy_spider)
+            processed = middleware.process_request(original, foo_spider)
 
         crawlera_meta = original.meta.get("crawlera_fetch")
         if crawlera_meta.get("skip"):
@@ -87,7 +86,7 @@ def test_process_request_default_args():
 
     for case in deepcopy(test_requests):
         original = case["original"]
-        processed = middleware.process_request(original, dummy_spider)
+        processed = middleware.process_request(original, foo_spider)
 
         crawlera_meta = original.meta.get("crawlera_fetch")
         if crawlera_meta.get("skip"):
@@ -106,5 +105,5 @@ def test_process_request_scrapy_1():
     middleware = get_test_middleware()
     request = Request("https://example.org")
     with shub_jobkey_env_variable():
-        processed = middleware.process_request(request, dummy_spider)
+        processed = middleware.process_request(request, foo_spider)
     assert processed.flags == ["original url: https://example.org"]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1,14 +1,13 @@
 import json
 import os
 from contextlib import contextmanager
-from copy import deepcopy
 from unittest.mock import patch
 
 from scrapy import Request
 
 from crawlera_fetch import DownloadSlotPolicy
 
-from tests.data.requests import test_requests
+from tests.data.requests import get_test_requests
 from tests.utils import foo_spider, get_test_middleware, mocked_time
 
 
@@ -28,7 +27,7 @@ def shub_jobkey_env_variable():
 def test_process_request():
     middleware = get_test_middleware()
 
-    for case in deepcopy(test_requests):
+    for case in get_test_requests():
         original = case["original"]
         expected = case["expected"]
 
@@ -55,7 +54,7 @@ def test_process_request_single_download_slot():
         settings={"CRAWLERA_FETCH_DOWNLOAD_SLOT_POLICY": DownloadSlotPolicy.Single}
     )
 
-    for case in deepcopy(test_requests):
+    for case in get_test_requests():
         original = case["original"]
         expected = case["expected"]
         if expected:
@@ -84,7 +83,7 @@ def test_process_request_default_args():
         settings={"CRAWLERA_FETCH_DEFAULT_ARGS": {"foo": "bar", "answer": "42"}}
     )
 
-    for case in deepcopy(test_requests):
+    for case in get_test_requests():
         original = case["original"]
         processed = middleware.process_request(original, foo_spider)
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -8,9 +8,8 @@ from testfixtures import LogCapture
 
 from crawlera_fetch.middleware import CrawleraFetchException
 
-from tests.data import dummy_spider
 from tests.data.responses import test_responses
-from tests.utils import get_test_middleware, mocked_time
+from tests.utils import foo_spider, get_test_middleware, mocked_time
 
 
 def test_process_response():
@@ -20,7 +19,7 @@ def test_process_response():
         original = case["original"]
         expected = case["expected"]
 
-        processed = middleware.process_response(original.request, original, dummy_spider)
+        processed = middleware.process_response(original.request, original, foo_spider)
 
         assert type(processed) is type(expected)
         assert processed.url == expected.url
@@ -52,7 +51,7 @@ def test_process_response_skip():
     )
 
     middleware = get_test_middleware()
-    processed = middleware.process_response(response.request, response, dummy_spider)
+    processed = middleware.process_response(response.request, response, foo_spider)
 
     assert response is processed
 
@@ -68,7 +67,7 @@ def test_process_response_error():
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://example.org"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },
@@ -91,7 +90,7 @@ def test_process_response_error():
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://example.org"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },
@@ -107,7 +106,7 @@ def test_process_response_error():
                         "timing": {"start_ts": mocked_time()},
                         "original_request": request_to_dict(
                             Request("https://example.org"),
-                            spider=dummy_spider,
+                            spider=foo_spider,
                         ),
                     }
                 },
@@ -130,7 +129,7 @@ def test_process_response_error():
     middleware_raise = get_test_middleware(settings={"CRAWLERA_FETCH_RAISE_ON_ERROR": True})
     for response in response_list:
         with pytest.raises(CrawleraFetchException):
-            middleware_raise.process_response(response.request, response, dummy_spider)
+            middleware_raise.process_response(response.request, response, foo_spider)
 
     assert middleware_raise.stats.get_value("crawlera_fetch/response_error") == 3
     assert middleware_raise.stats.get_value("crawlera_fetch/response_error/bad_proxy_auth") == 1
@@ -140,7 +139,7 @@ def test_process_response_error():
     middleware_log = get_test_middleware(settings={"CRAWLERA_FETCH_RAISE_ON_ERROR": False})
     with LogCapture() as logs:
         for response in response_list:
-            processed = middleware_log.process_response(response.request, response, dummy_spider)
+            processed = middleware_log.process_response(response.request, response, foo_spider)
             assert response is processed
 
     logs.check_present(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,6 +24,12 @@ class MockEngine:
 class FooSpider(Spider):
     name = "foo"
 
+    def foo_callback(self, response):
+        pass
+
+
+foo_spider = FooSpider()
+
 
 def get_test_middleware(settings=None):
     settings_dict = SETTINGS.copy()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,black,typing,py3.5,py3.6,py3.7,py3.8
+envlist = flake8,black,typing,py35-pinned,py36,py37,py38
 
 
 [testenv]
@@ -23,14 +23,17 @@ deps = mypy==0.770
 basepython = python3.8
 commands = mypy --ignore-missing-imports --follow-imports=skip crawlera_fetch tests
 
-[testenv:py3.5]
+[testenv:py35-pinned]
+deps =
+    -rtests/requirements.txt
+    scrapy==1.8
 basepython = python3.5
 
-[testenv:py3.6]
+[testenv:py36]
 basepython = python3.6
 
-[testenv:py3.7]
+[testenv:py37]
 basepython = python3.7
 
-[testenv:py3.8]
+[testenv:py38]
 basepython = python3.8


### PR DESCRIPTION
Updated the test suite to detect the issue reported in #5.

Please take a look if you have the time @edorofeev @starrify @Gallaecio @wRAR

Tests fail now if the fix from #6 is reverted:
```diff
diff --git crawlera_fetch/middleware.py crawlera_fetch/middleware.py
index 38c1527..1bbb571 100644
--- crawlera_fetch/middleware.py
+++ crawlera_fetch/middleware.py
@@ -103,7 +103,7 @@ class CrawleraFetchMiddleware:
         body_json = json.dumps(body)
 
         additional_meta = {
-            "original_request": request_to_dict(request, spider=spider),
+            "original_request": request_to_dict(request),
             "timing": {"start_ts": time.time()},
         }
         crawlera_meta.update(additional_meta)
@@ -134,7 +134,7 @@ class CrawleraFetchMiddleware:
         if crawlera_meta.get("skip") or not crawlera_meta.get("original_request"):
             return response
 
-        original_request = request_from_dict(crawlera_meta["original_request"], spider=spider)
+        original_request = request_from_dict(crawlera_meta["original_request"])
 
         self.stats.inc_value("crawlera_fetch/response_count")
         self._calculate_latency(request)

```
 
```
$ tox -e py38
GLOB sdist-make: /.../scrapy-crawlera-fetch/setup.py
py38 inst-nodeps: /.../scrapy-crawlera-fetch/.tox/.tmp/package/1/scrapy-crawlera-fetch-0.0.1.zip
py38 installed: attrs==20.3.0,Automat==20.2.0,cffi==1.14.4,constantly==15.1.0,coverage==5.3,cryptography==3.3.1,cssselect==1.1.0,hyperlink==20.0.1,idna==2.10,incremental==17.5.0,itemadapter==0.2.0,itemloaders==1.0.4,jmespath==0.10.0,lxml==4.6.2,more-itertools==8.6.0,packaging==20.8,parsel==1.6.0,pluggy==0.13.1,Protego==0.1.16,py==1.10.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,PyDispatcher==2.0.5,PyHamcrest==2.0.2,pyOpenSSL==20.0.1,pyparsing==2.4.7,pytest==5.3.5,pytest-cov==2.10.1,queuelib==1.5.0,Scrapy==2.4.1,scrapy-crawlera-fetch @ file:///.../scrapy-crawlera-fetch/.tox/.tmp/package/1/scrapy-crawlera-fetch-0.0.1.zip,service-identity==18.1.0,six==1.15.0,testfixtures==6.17.0,Twisted==20.3.0,w3lib==1.22.0,wcwidth==0.2.5,zope.interface==5.2.0
py38 run-test-pre: PYTHONHASHSEED='545854883'
py38 run-test: commands[0] | py.test --verbose --cov=crawlera_fetch --cov-report=term-missing --cov-report=html --cov-report=xml crawlera_fetch tests
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.8.6, pytest-5.3.5, py-1.10.0, pluggy-0.13.1 -- /.../scrapy-crawlera-fetch/.tox/py38/bin/python
cachedir: .tox/py38/.pytest_cache
rootdir: /.../scrapy-crawlera-fetch
plugins: cov-2.10.1
collected 13 items

tests/test_config.py::test_not_enabled PASSED                                                                                                                                                        [  7%]
tests/test_config.py::test_no_apikey PASSED                                                                                                                                                          [ 15%]
tests/test_config.py::test_config_values PASSED                                                                                                                                                      [ 23%]
tests/test_logformatter.py::test_log_formatter_scrapy_1 SKIPPED                                                                                                                                      [ 30%]
tests/test_logformatter.py::test_log_formatter_scrapy_2 FAILED                                                                                                                                       [ 38%]
tests/test_requests.py::test_process_request FAILED                                                                                                                                                  [ 46%]
tests/test_requests.py::test_process_request_single_download_slot FAILED                                                                                                                             [ 53%]
tests/test_requests.py::test_process_request_default_args FAILED                                                                                                                                     [ 61%]
tests/test_requests.py::test_process_request_scrapy_1 PASSED                                                                                                                                         [ 69%]
tests/test_responses.py::test_process_response PASSED                                                                                                                                                [ 76%]
tests/test_responses.py::test_process_response_skip PASSED                                                                                                                                           [ 84%]
tests/test_responses.py::test_process_response_error PASSED                                                                                                                                          [ 92%]
tests/test_stats.py::test_stats PASSED                                                                                                                                                               [100%]

================================================================================================= FAILURES =================================================================================================
_______________________________________________________________________________________ test_log_formatter_scrapy_2 ________________________________________________________________________________________

    @unittest.skipIf(scrapy_version < (2, 0, 0), "Scrapy >= 2.0 only")
    def test_log_formatter_scrapy_2():
        middleware = get_test_middleware()
        logformatter = CrawleraFetchLogFormatter()
        formatter = Formatter()

        for case in deepcopy(test_requests):
            original = case["original"]
            response = Response(original.url)
>           processed = middleware.process_request(original, foo_spider)

tests/test_logformatter.py:51:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
crawlera_fetch/middleware.py:106: in process_request
    "original_request": request_to_dict(request),
.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:19: in request_to_dict
    cb = _find_method(spider, cb)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = None, func = <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf06d90>>

    def _find_method(obj, func):
        # Only instance methods contain ``__func__``
        if obj and hasattr(func, '__func__'):
            members = inspect.getmembers(obj, predicate=inspect.ismethod)
            for name, obj_func in members:
                # We need to use __func__ to access the original
                # function object because instance method objects
                # are generated each time attribute is retrieved from
                # instance.
                #
                # Reference: The standard type hierarchy
                # https://docs.python.org/3/reference/datamodel.html
                if obj_func.__func__ is func.__func__:
                    return name
>       raise ValueError(f"Function {func} is not an instance method in: {obj}")
E       ValueError: Function <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf06d90>> is not an instance method in: None

.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:87: ValueError
___________________________________________________________________________________________ test_process_request ___________________________________________________________________________________________

    @patch("time.time", mocked_time)
    def test_process_request():
        middleware = get_test_middleware()

        for case in deepcopy(test_requests):
            original = case["original"]
            expected = case["expected"]

            with shub_jobkey_env_variable():
>               processed = middleware.process_request(original, foo_spider)

tests/test_requests.py:36:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
crawlera_fetch/middleware.py:106: in process_request
    "original_request": request_to_dict(request),
.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:19: in request_to_dict
    cb = _find_method(spider, cb)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = None, func = <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf20f10>>

    def _find_method(obj, func):
        # Only instance methods contain ``__func__``
        if obj and hasattr(func, '__func__'):
            members = inspect.getmembers(obj, predicate=inspect.ismethod)
            for name, obj_func in members:
                # We need to use __func__ to access the original
                # function object because instance method objects
                # are generated each time attribute is retrieved from
                # instance.
                #
                # Reference: The standard type hierarchy
                # https://docs.python.org/3/reference/datamodel.html
                if obj_func.__func__ is func.__func__:
                    return name
>       raise ValueError(f"Function {func} is not an instance method in: {obj}")
E       ValueError: Function <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf20f10>> is not an instance method in: None

.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:87: ValueError
________________________________________________________________________________ test_process_request_single_download_slot _________________________________________________________________________________

    @patch("time.time", mocked_time)
    def test_process_request_single_download_slot():
        middleware = get_test_middleware(
            settings={"CRAWLERA_FETCH_DOWNLOAD_SLOT_POLICY": DownloadSlotPolicy.Single}
        )

        for case in deepcopy(test_requests):
            original = case["original"]
            expected = case["expected"]
            if expected:
                expected.meta["download_slot"] = "__crawlera_fetch__"

            with shub_jobkey_env_variable():
>               processed = middleware.process_request(original, foo_spider)

tests/test_requests.py:65:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
crawlera_fetch/middleware.py:106: in process_request
    "original_request": request_to_dict(request),
.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:19: in request_to_dict
    cb = _find_method(spider, cb)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = None, func = <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf6a850>>

    def _find_method(obj, func):
        # Only instance methods contain ``__func__``
        if obj and hasattr(func, '__func__'):
            members = inspect.getmembers(obj, predicate=inspect.ismethod)
            for name, obj_func in members:
                # We need to use __func__ to access the original
                # function object because instance method objects
                # are generated each time attribute is retrieved from
                # instance.
                #
                # Reference: The standard type hierarchy
                # https://docs.python.org/3/reference/datamodel.html
                if obj_func.__func__ is func.__func__:
                    return name
>       raise ValueError(f"Function {func} is not an instance method in: {obj}")
E       ValueError: Function <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bf6a850>> is not an instance method in: None

.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:87: ValueError
____________________________________________________________________________________ test_process_request_default_args _____________________________________________________________________________________

    @patch("time.time", mocked_time)
    def test_process_request_default_args():
        middleware = get_test_middleware(
            settings={"CRAWLERA_FETCH_DEFAULT_ARGS": {"foo": "bar", "answer": "42"}}
        )

        for case in deepcopy(test_requests):
            original = case["original"]
>           processed = middleware.process_request(original, foo_spider)

tests/test_requests.py:89:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
crawlera_fetch/middleware.py:106: in process_request
    "original_request": request_to_dict(request),
.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:19: in request_to_dict
    cb = _find_method(spider, cb)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

obj = None, func = <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bff2a60>>

    def _find_method(obj, func):
        # Only instance methods contain ``__func__``
        if obj and hasattr(func, '__func__'):
            members = inspect.getmembers(obj, predicate=inspect.ismethod)
            for name, obj_func in members:
                # We need to use __func__ to access the original
                # function object because instance method objects
                # are generated each time attribute is retrieved from
                # instance.
                #
                # Reference: The standard type hierarchy
                # https://docs.python.org/3/reference/datamodel.html
                if obj_func.__func__ is func.__func__:
                    return name
>       raise ValueError(f"Function {func} is not an instance method in: {obj}")
E       ValueError: Function <bound method FooSpider.foo_callback of <FooSpider 'foo' at 0x7f825bff2a60>> is not an instance method in: None

.tox/py38/lib/python3.8/site-packages/scrapy/utils/reqser.py:87: ValueError

---------- coverage: platform darwin, python 3.8.6-final-0 -----------
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
crawlera_fetch/__init__.py           2      0   100%
crawlera_fetch/logformatter.py      20      0   100%
crawlera_fetch/middleware.py       140      1    99%   91
--------------------------------------------------------------
TOTAL                              162      1    99%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

================================================================================== 4 failed, 8 passed, 1 skipped in 0.87s ==================================================================================
ERROR: InvocationError for command /.../scrapy-crawlera-fetch/.tox/py38/bin/py.test --verbose --cov=crawlera_fetch --cov-report=term-missing --cov-report=html --cov-report=xml crawlera_fetch tests (exited with code 1)
_________________________________________________________________________________________________ summary __________________________________________________________________________________________________
ERROR:   py38: commands failed

```