### PR TITLE
crawlera_fetch_enabled spider attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Crawlera middleware won't be able to handle them.
 ### Settings
 
 * `CRAWLERA_FETCH_ENABLED` (type `bool`, default `False`). Whether or not the middleware will be enabled,
-    i.e. requests should be downloaded using the Crawlera Fetch API
+    i.e. requests should be downloaded using the Crawlera Fetch API. The `crawlera_fetch_enabled` spider
+    attribute takes precedence over this setting.
 
 * `CRAWLERA_FETCH_APIKEY` (type `str`). API key to be used to authenticate against the Crawlera endpoint
     (mandatory if enabled)
@@ -66,6 +67,11 @@ Crawlera middleware won't be able to handle them.
 * `CRAWLERA_FETCH_DEFAULT_ARGS` (type `dict`, default `{}`)
     Default values to be sent to the Crawlera Fetch API. For instance, set to `{"device": "mobile"}`
     to render all requests with a mobile profile.
+
+### Spider attributes
+
+* `crawlera_fetch_enabled` (type `bool`, default `False`). Whether or not the middleware will be enabled.
+    Takes precedence over the `CRAWLERA_FETCH_ENABLED` setting.
 
 ### Log formatter
 

--- a/crawlera_fetch/middleware.py
+++ b/crawlera_fetch/middleware.py
@@ -58,7 +58,7 @@ class CrawleraFetchMiddleware:
         return middleware
 
     def _read_settings(self, settings):
-        if settings.get("CRAWLERA_FETCH_APIKEY") is None:
+        if not settings.get("CRAWLERA_FETCH_APIKEY"):
             self.enabled = False
             logger.info("Crawlera Fetch API cannot be used without an apikey")
             return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
-import pytest
-from scrapy.exceptions import NotConfigured
+from scrapy import Spider
 from scrapy.utils.test import get_crawler
 
 from crawlera_fetch import CrawleraFetchMiddleware
@@ -7,21 +6,82 @@ from crawlera_fetch import CrawleraFetchMiddleware
 from tests.data import SETTINGS
 
 
-def test_not_enabled():
-    with pytest.raises(NotConfigured):
-        crawler = get_crawler(settings_dict={"CRAWLERA_FETCH_ENABLED": False})
-        CrawleraFetchMiddleware.from_crawler(crawler)
+def test_disable_via_setting():
+    class FooSpider(Spider):
+        name = "foo"
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(FooSpider, settings_dict={"CRAWLERA_FETCH_ENABLED": False})
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
+
+
+def test_disable_via_spider_attribute_bool():
+    class FooSpider(Spider):
+        name = "foo"
+        crawlera_fetch_enabled = False
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(spidercls=FooSpider)
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
+
+
+def test_disable_via_spider_attribute_int():
+    class FooSpider(Spider):
+        name = "foo"
+        crawlera_fetch_enabled = 0
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(spidercls=FooSpider)
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
+
+
+def test_disable_via_spider_attribute_str():
+    class FooSpider(Spider):
+        name = "foo"
+        crawlera_fetch_enabled = "False"
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(spidercls=FooSpider)
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
+
+
+def test_disable_override():
+    class FooSpider(Spider):
+        name = "foo"
+        crawlera_fetch_enabled = False
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(FooSpider, settings_dict={"CRAWLERA_FETCH_ENABLED": True})
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
 
 
 def test_no_apikey():
-    with pytest.raises(NotConfigured):
-        crawler = get_crawler(settings_dict={"CRAWLERA_FETCH_ENABLED": True})
-        CrawleraFetchMiddleware.from_crawler(crawler)
+    class FooSpider(Spider):
+        name = "foo"
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(settings_dict={"CRAWLERA_FETCH_ENABLED": True})
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+    assert not middleware.enabled
 
 
 def test_config_values():
-    crawler = get_crawler(settings_dict=SETTINGS)
-    middleware = CrawleraFetchMiddleware.from_crawler(crawler)
+    FooSpider = type("FooSpider", (Spider,), {"name": "foo"})
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(spidercls=FooSpider, settings_dict=SETTINGS)
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
 
     assert middleware.apikey == SETTINGS["CRAWLERA_FETCH_APIKEY"]
     assert middleware.url == SETTINGS["CRAWLERA_FETCH_URL"]
@@ -29,10 +89,14 @@ def test_config_values():
 
 
 def test_config_without_apipass():
-    s = SETTINGS.copy()
-    s.pop("CRAWLERA_FETCH_APIPASS", None)
-    crawler = get_crawler(settings_dict=s)
-    middleware = CrawleraFetchMiddleware.from_crawler(crawler)
+    settings = SETTINGS.copy()
+    settings.pop("CRAWLERA_FETCH_APIPASS", None)
+
+    FooSpider = type("FooSpider", (Spider,), {"name": "foo"})
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(spidercls=FooSpider, settings_dict=settings)
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
 
     assert middleware.apikey == SETTINGS["CRAWLERA_FETCH_APIKEY"]
     assert middleware.url == SETTINGS["CRAWLERA_FETCH_URL"]

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -23,6 +23,14 @@ def shub_jobkey_env_variable():
             os.environ["SHUB_JOBKEY"] = SHUB_JOBKEY_OLD
 
 
+def test_process_request_disabled():
+    middleware = get_test_middleware(settings={"CRAWLERA_FETCH_ENABLED": False})
+    for case in get_test_requests():
+        request = case["original"]
+        with shub_jobkey_env_variable():
+            assert middleware.process_request(request, foo_spider) is None
+
+
 @patch("time.time", mocked_time)
 def test_process_request():
     middleware = get_test_middleware()

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -12,6 +12,13 @@ from tests.data.responses import test_responses
 from tests.utils import foo_spider, get_test_middleware, mocked_time
 
 
+def test_process_response_disabled():
+    middleware = get_test_middleware(settings={"CRAWLERA_FETCH_ENABLED": False})
+    for case in test_responses:
+        response = case["original"]
+        assert middleware.process_response(response.request, response, foo_spider) is response
+
+
 def test_process_response():
     middleware = get_test_middleware()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,9 +34,14 @@ foo_spider = FooSpider()
 def get_test_middleware(settings=None):
     settings_dict = SETTINGS.copy()
     settings_dict.update(settings or {})
-    crawler = get_crawler(FooSpider, settings_dict=settings_dict)
-    crawler.engine = MockEngine()
-    middleware = CrawleraFetchMiddleware.from_crawler(crawler)
+
+    foo_spider = FooSpider()
+    foo_spider.crawler = get_crawler(FooSpider, settings_dict=settings_dict)
+    foo_spider.crawler.engine = MockEngine()
+
+    middleware = CrawleraFetchMiddleware.from_crawler(foo_spider.crawler)
+    middleware.spider_opened(foo_spider)
+
     return middleware
 
 


### PR DESCRIPTION
Allow to enable/disable the middleware on a spider-basis without the need to override `Spider.custom_settings`, which can be cumbersome in certain circumstances (CLI and SC invocations, for instance).

Moves away from the `scrapy.exceptions.NotConfigured` approach to disable the middleware, just like [scrapy-crawlera](https://github.com/scrapy-plugins/scrapy-crawlera), because the Spider object is not available on `__init__`.

/cc @PyExplorer, @edorofeev, @akshayphilar